### PR TITLE
Enable alert when no alt text is found

### DIFF
--- a/chrome/content_scripts/getClickTarget.js
+++ b/chrome/content_scripts/getClickTarget.js
@@ -23,6 +23,10 @@ function copyToClipboard(textToCopy) {
     }
 }
 
+function noAltFound() {
+    alert("Image has no alt text");
+}
+
 document.addEventListener("contextmenu", function(event){
     clickedEl = event.target;
     return true;
@@ -35,6 +39,8 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         copyToClipboard(clickedEl.alt)
             .catch(e => console.log(`Error copying text to clipboard: ${e}`));
         clickedEl = null;
+    } else if (request.type === "alertNoAlt") {
+        noAltFound();
     }
     return true;
 });

--- a/chrome/menu.js
+++ b/chrome/menu.js
@@ -26,7 +26,7 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
             if (alt) {
                 copyAlt(tab);
             } else {
-                noAltFound();
+                noAltFound(tab);
             }
         });
     }
@@ -35,13 +35,16 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
 
 function findAlt(tab, callback) {
     chrome.tabs.sendMessage(tab.id, {type: "getClickedEl"}, {}, function (response) {
-        callback(response.alt);
+        callback(response?.alt);
         return true;
     })
 }
 
-function noAltFound() {
-    alert("Image has no alt text");
+function noAltFound(tab) {
+    chrome.tabs.sendMessage(tab.id, {type: "alertNoAlt"}, {},
+        resp => {
+            return true;
+        })
 }
 
 function copyAlt(tab) {


### PR DESCRIPTION
The function noAltFound couldn't run due to being ran from the extension's context instead of the tab's. I've moved the noAltFound function to /content_scripts/getClickTarget.js, and replaced its contents in /menu.js with a sendMessage call to call it in the tab.